### PR TITLE
clang-tidy and clang-format Scripts

### DIFF
--- a/format_codebase.sh
+++ b/format_codebase.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
 cpp_files=$(find src/ -name "*cpp")
 hpp_files=$(find src/ -name "*hpp")
-include_hpp_files=$(find include/ -name "*hpp")
-clang-format --style=file -i $cpp_files $hpp_files $include_hpp_files
+clang-format --style=file -i $cpp_files $hpp_files

--- a/lint_codebase.sh
+++ b/lint_codebase.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
 cpp_files=$(find ../src/ -name "*cpp")
 hpp_files=$(find ../src/ -name "*hpp")
-include_hpp_files=$(find ../include/ -name "*hpp")
-clang-tidy --format-style=file $cpp_files $hpp_files $include_hpp_files
+clang-tidy --format-style=file $cpp_files $hpp_files


### PR DESCRIPTION
Do not lint or format the include directory.